### PR TITLE
function is now a type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1030,7 +1030,7 @@ typeof sayHi();
 
 The `sayHi` function returns the returned value of the immediately invoked function (IIFE). This function returned `0`, which is type `"number"`.
 
-FYI: there are only 7 built-in types: `null`, `undefined`, `boolean`, `number`, `string`, `object`, and `symbol`. `"function"` is not a type, since functions are objects, it's of type `"object"`.
+FYI: there are only 8 built-in types: `null`, `undefined`, `boolean`, `number`, `string`, `object`, `symbol` and `function`.
 
 </p>
 </details>


### PR DESCRIPTION
I think there might be an error in the exercise 34, the answer is right but the explanation is not updated, today function is a type https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof

`const foo = () =>0;
typeof foo //function`