### PR TITLE
Better clarification for question 27

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,7 +798,7 @@ for (let i = 1; i < 5; i++) {
 
 #### Answer: C
 
-The `continue` statement skips an iteration if a certain condition returns `true`.
+The `continue` statement skips an iteration and does in this case if `i` is equal to `3`.
 
 </p>
 </details>


### PR DESCRIPTION
Might be a little far-fetched, but still...

The `continue` statement always skips an iteration. It is up to the developer to let this happen in a condition.