### PR TITLE
Correction du nom de la constante "numberes".

### DIFF
--- a/fr-FR/README_fr-FR.md
+++ b/fr-FR/README_fr-FR.md
@@ -1803,7 +1803,7 @@ La variable `name` a été déclarée avec un mot-clé `const`. Par conséquent,
 
 ```javascript
 const numbers = [1, 2, 3, 4, 5];
-const [y] = numberes;
+const [y] = numbers;
 
 console.log(y);
 ```


### PR DESCRIPTION
(line - 1806)
Faute de frappe dans le code de la question 59.

eng:
Naming correction on question 59. "numberes" -> numbers