### PR TITLE
Update 95 (automatic semicolon insertion)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3009,7 +3009,7 @@ The above example works. This returns the array `[ 'banana', 'apple', 'orange', 
 function nums(a, b) {
   if (a > b) console.log('a is bigger');
   else console.log('b is bigger');
-  return;
+  return
   a + b;
 }
 


### PR DESCRIPTION
Request to remove the semicolon from the return line of `nums(a, b)`, as this question doesn't make much sense with it in place - it's built around the gotcha of the semicolon being missing. The semicolons were potentially auto-added by a linter due to the exact reason discussed in the answer, but in this case it's important to keep that ambiguity.
It might be worthwhile to remove the other semicolons in the function, as well (which would match the formatting of some of the translations, such as NL), but this is the minimum required change for this to make sense again.