### PR TITLE
🇫🇷 Fixed typo 🐛

### DIFF
--- a/fr-FR/README_fr-FR.md
+++ b/fr-FR/README_fr-FR.md
@@ -685,7 +685,7 @@ sessionStorage.setItem("cool_secret", 123);
 
 #### Réponse : B
 
-La donnée stocké dans le `sessionStorage` est supprimée après la fermeture de l'onglet.
+La donnée stockée dans le `sessionStorage` est supprimée après la fermeture de l'onglet.
 
 Si vous utilisez le `localStorage`, la donnée sera là pour toujours, jusqu'à ce que, par exemple, `localStorage.clear()` soit invoquée.
 


### PR DESCRIPTION
"donnée" is feminine and the following verb "stocké" agreements with it (stocké -> stockée).