### PR TITLE
Fix to #114: Add `clearInterval` to explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3685,7 +3685,11 @@ config = null;
 
 #### Answer: C
 
-Normally when we set objects equal to `null`, those objects get _garbage collected_ as there is no reference anymore to that object. However, since the callback function within `setInterval` is an arrow function (thus bound to the `config` object), the callback function still holds a reference to the `config` object. As long as there is a reference, the object won't get garbage collected. Since it's not garbage collected, the `setInterval` callback function will still get invoked every 1000ms (1s).
+Normally when we set objects equal to `null`, those objects get _garbage collected_ as there is no reference anymore to that object. However, since the callback function within `setInterval` is an arrow function (thus bound to the `config` object), the callback function still holds a reference to the `config` object. 
+As long as there is a reference, the object won't get garbage collected. 
+Since this is an interval, setting `config` to `null` or `delete`-ing `config.alert` won't garbage-collect the interval, so the interval will still be called. 
+It should be cleared with `clearInterval(config.alert)` to remove it from memory.
+Since it was not cleared, the `setInterval` callback function will still get invoked every 1000ms (1s).
 
 </p>
 </details>


### PR DESCRIPTION
Clearing an interval, other than reloading the browser/process, is the only way to garbage-collect an already set interval, so it would stop running.