### PR TITLE
ignore .DS_Store files created on OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
This pull request creates a `.gitignore` file to help Mac OS users ignore `.DS_Store` files.