### PR TITLE
add `Object.seal` link in 136 for easier reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -4434,7 +4434,7 @@ Object.seal(person);
 
 #### Answer: A
 
-With `Object.seal` we can prevent new properies from being _added_, or existing properties to be _removed_.
+With [`Object.seal`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal)  we can prevent new properies from being _added_, or existing properties to be _removed_.
 
 However, you can still modify the value of existing properties.
 


### PR DESCRIPTION
I think it would be useful to readers if we linked to the [MDN documentation for `Object.seal`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal) in [136. Which of the following will modify the person object?](https://github.com/lydiahallie/javascript-questions#136-which-of-the-following-will-modify-the-person-object).