### PR TITLE
Fix typo in answer to question 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ console.log(greetign);
 It logs the object, because we just created an empty object on the global object! When we mistyped `greeting` as `greetign`, the JS interpreter actually saw this as:
 
 1. `global.greetign = {}` in Node.js
-2. `window.greetign = {}`, `frames.geetign = {}` and `self.greetign` in browsers.
+2. `window.greetign = {}`, `frames.greetign = {}` and `self.greetign` in browsers.
 3. `self.greetign` in web workers.
 4. `globalThis.greetign` in all environments.
 


### PR DESCRIPTION
There is a typo in the line below (the answer to question 9).

> window.greetign = {}, frames.geetign = {} and self.greetign in browsers.

There is a missing _r_ in _frames.geetign_.

It should be _frames.greetign_

This PR corrects it.