### PR TITLE
Fixes spelling mistakes and corrects one answer

### DIFF
--- a/pt-BR/README_pt_BR.md
+++ b/pt-BR/README_pt_BR.md
@@ -1097,7 +1097,7 @@ Funções construtoras, como `new Number` e `new Boolean` são truthy.
 
 ---
 
-###### 36. Qual é a sáida?
+###### 36. Qual é a saída?
 
 ```javascript
 console.log(typeof typeof 1);
@@ -2202,11 +2202,11 @@ console.log(/* 2 */); // O JavaScript também ama você ❤️
 
 #### Resposta: C
 
-Uma função geradora "pausa" a sua execução quando encontra a palavra-chave `yield`. Primeiro, temos que deixar a função produzir a string "Você ama JavaScript?", o que pode ser feito chamando `game.next().value`.
+Uma função geradora "pausa" a sua execução quando encontra a palavra-chave `yield`. Primeiro, temos que deixar a função produzir a string "Você ama JavaScript?", o que pode ser feito chamando `jogo.next().value`.
 
 Cada linha é executada, até encontrar a primeira palavra-chave `yield`. Há uma palavra-chave `yield` na primeira linha da função: a execução para com o primeiro retorno! _Isso significa que a variável `resposta` ainda não foi definida!_
 
-Quando chamamos `game.next("Sim").value`, o `yield` anterior é substituído pelo valor dos parâmetros passados para a função `next()`, `"Sim"` neste caso. O valor da variável `"resposta"` agora é igual a `"Sim"`. A condição da instrução if retorna `false` e `JavaScript também ama você ❤️` é registrada.
+Quando chamamos `jogo.next("Sim").value`, o `yield` anterior é substituído pelo valor dos parâmetros passados para a função `next()`, `"Sim"` neste caso. O valor da variável `"resposta"` agora é igual a `"Sim"`. A condição da instrução if retorna `false` e `JavaScript também ama você ❤️` é registrada.
 
 </p>
 </details>

--- a/pt-BR/README_pt_BR.md
+++ b/pt-BR/README_pt_BR.md
@@ -2360,13 +2360,13 @@ console.log(name);
 <details><summary><b>Answer</b></summary>
 <p>
 
-#### Answer: C
+#### Answer: D
 
 Quando descompactamos a propriedade `name` do objeto do lado direito, atribuímos seu valor `"Lydia"` a uma variável com o nome `myName`.
 
 Com `{ name: myName }`, informamos ao JavaScript que queremos criar uma nova variável chamada `myName` com o valor da propriedade `name` no lado direito.
 
-Como tentamos registrar `name`, uma variável que não está definida, `undefined` é retornado na atribuição do lado esquerdo. Mais tarde, o valor de `Lydia` é armazenado através da atribuição de desestruturação.
+Quando tentamos mostrar o conteúdo de `name`, uma variável que não está definida, recebemos o erro `ReferenceError`.
 
 </p>
 </details>


### PR DESCRIPTION
Changes on pt-BR version
- Question 36: Fixes spelling mistake from "sáida" to "saída"
- Question 71: Object name was translated to Portuguese on question, but not on answer. Fixes that.
- Question 76: Correct answer is D, not C. Explanation provided. Also according to the en-US it is answer D indeed.