### PR TITLE
Question-15 correct explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ sum(1, '2');
 
 #### Answer: C
 
-JavaScript is a **dynamically typed language**: we don't specify what types certain variables are. Values can automatically be converted into another type without you knowing, which is called _implicit type coercion_. **Coercion** is converting from one type into another.
+JavaScript is a **weakly typed language**: Values can automatically be converted into another type without you knowing, which is called _implicit type coercion_. **Coercion** is converting from one type into another.
 
 In this example, JavaScript converts the number `1` into a string, in order for the function to make sense and return a value. During the addition of a numeric type (`1`) and a string type (`'2'`), the number is treated as a string. We can concatenate strings like `"Hello" + "World"`, so what's happening here is `"1" + "2"` which returns `"12"`.
 


### PR DESCRIPTION
It's true that JavaScript is dynamically typed languages, but the reason for type coercion is that JavaScript is weakly typed languages.

 In dynamically typed languages, you don't need to explicitly specify the type of a variable. Instead, the interpreter or runtime engine figures it out, and variables can hold different types of data at different times.

 In weakly typed languages, the language tries to make sense of operations even when the types of the operands don't exactly match, often converting one type to another automatically. it allows implicit type conversions (type coercion) between different data types.