### PR TITLE
fix 110 explanation trying to reassign a constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -3584,8 +3584,8 @@ const jsonArray = JSON.stringify([1, 2, 3]); // '[1, 2, 3]'
 JSON.parse(jsonArray); // [1, 2, 3]
 
 // Stringifying an object  into valid JSON, then parsing the JSON string to a JavaScript value:
-const jsonArray = JSON.stringify({ name: 'Lydia' }); // '{"name":"Lydia"}'
-JSON.parse(jsonArray); // { name: 'Lydia' }
+const jsonObject = JSON.stringify({ name: 'Lydia' }); // '{"name":"Lydia"}'
+JSON.parse(jsonObject); // { name: 'Lydia' }
 ```
 
 </p>


### PR DESCRIPTION
In explanation for 110 `JSON.parse()`, renamed second `jsonArray` to `jsonObject`. Preceding lines already declared a `jsonArray` constant.